### PR TITLE
Updated PicoCTF spelling and added new docker resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For a list of free hacking books available for download, go [here](https://githu
  * `docker-compose build && docker-compose up` - [OWASP NodeGoat](https://github.com/owasp/nodegoat#option-3---run-nodegoat-on-docker)
  * `docker pull citizenstig/nowasp` - [OWASP Mutillidae II Web Pen-Test Practice Application](https://hub.docker.com/r/citizenstig/nowasp/)
  * `docker pull bkimminich/juice-shop` - [OWASP Juice Shop](https://github.com/bkimminich/juice-shop#docker-container--)
+ * `docker pull phocean/msf` - [Docker Metasploit](https://hub.docker.com/r/phocean/msf/)
 
 ## General
  * [Exploit database](https://www.exploit-db.com/) - An ultimate archive of exploits and vulnerable software
@@ -207,7 +208,7 @@ For a list of free hacking books available for download, go [here](https://githu
  * [Boston Key Party CTF](http://bostonkeyparty.net/)
  * [ZeroDays CTF](https://zerodays.ie/)
  * [Insomni’hack](https://insomnihack.ch/)
- * [Picp CTF](https://picoctf.com/) 
+ * [Pico CTF](https://picoctf.com/) 
  * [prompt(1) to win](http://prompt.ml/) - XSS Challeges
 
 ## General


### PR DESCRIPTION
Added a docker image repository for dockerised metasploit (as seen in https://github.com/enaqx/awesome-pentest).
Noted a spelling mistake for PicoCTF, which has been updated in the PR.