### PR TITLE
 Add `phpsploit` (C2 framework via PHP oneliner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ For a list of free hacking books available for download, go [here](https://githu
  * [SubFinder](https://github.com/subfinder/subfinder) - SubFinder is a subdomain discovery tool that discovers valid subdomains for any target using passive online sources.
  * [Findsubdomains](https://findsubdomains.com/) - A subdomains discovery tool that collects all possible subdomains from open source internet and validates them through various tools to provide accurate results.
  * [badtouch](https://github.com/kpcyrd/badtouch) - Scriptable network authentication cracker
+ * [PhpSploit](https://github.com/nil0x42/phpsploit) - Full-featured C2 framework which silently persists on webserver via evil PHP oneliner
 
 ## General
  * [Strong node.js](https://github.com/jesusprubio/strong-node) - An exhaustive checklist to assist in the source code security analysis of a node.js web service.


### PR DESCRIPTION
Add phpsploit tool (https://github.com/nil0x42/phpsploit):
Full-featured C2 framework which silently persists on webserver via evil PHP oneliner

PhpSploit is a well-known advanced & stealth PHP backdoor for persistence & privesc

