### PR TITLE
Add new site to Wargame/Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ For a list of free hacking books available for download, go [here](https://githu
  * [Gruyere](https://google-gruyere.appspot.com/)
  * [Others](https://www.owasp.org/index.php/OWASP_Vulnerable_Web_Applications_Directory_Project#tab=On-Line_apps)
  * [TryHackMe](https://tryhackme.com/) - Hands-on cyber security training through real-world scenarios.
+ * [LabEx](https://labex.io/skilltrees/cybersecurity) - Hands-on labs for cyber security, covering tools like Nmap, Wireshark, Kali, and more.
 
 ## Cryptography
  * [OverTheWire - Krypton](http://overthewire.org/wargames/krypton/)


### PR DESCRIPTION
Add LabEx to Wargame/Web section.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.