### PR TITLE
Add NullSec Linux to security OS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ For a list of free hacking books available for download, go [here](https://githu
 
  * [Security related Operating Systems @ Rawsec](https://inventory.raw.pm/operating_systems.html) - Complete list of security related operating systems
  * [Best Linux Penetration Testing Distributions @ CyberPunk](https://n0where.net/best-linux-penetration-testing-distributions/) - Description of main penetration testing distributions
+ * [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Debian-based security distro for hardware hacking with Flipper Zero, WiFi Pineapple, USB Rubber Ducky integration.
  * [Security @ Distrowatch](http://distrowatch.com/search.php?category=Security) - Website dedicated to talking about, reviewing and keeping up to date with open source operating systems
 
 


### PR DESCRIPTION
## Addition

Adding **NullSec Linux** to the OS section alongside other security resources.

### NullSec Linux Features

- **135+ specialized security tools**
- **5 editions**: Standard, Cloud Pentest, AI/ML Security, Hardware Hacking, Automotive Security
- **4 architectures**: AMD64, ARM64, RISC-V, Apple Silicon
- Cloud, AI/ML red teaming, hardware hacking, and automotive security tools

Repository: https://github.com/bad-antics/nullsec-linux