### PR TITLE
Add n01d-forge and n01d-machine to Forensic section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ For a list of free hacking books available for download, go [here](https://githu
  * [IPED - Indexador e Processador de Evidências Digitais](https://servicos.dpf.gov.br/ferramentas/IPED/) - Brazilian Federal Police Tool for Forensic Investigation
  * [CyLR](https://github.com/orlikoski/CyLR) - NTFS forensic image collector 
  * [CAINE](https://www.caine-live.net/)- CAINE is a Ubuntu-based app that offers a complete forensic environment that provides a graphical interface. This tool can be integrated into existing software tools as a module. It automatically extracts a timeline from RAM.
+ * [n01d-forge](https://github.com/bad-antics/n01d-forge) - Native Rust image burner with LUKS/VeraCrypt encryption support for creating secure forensic images and bootable drives.
+ * [n01d-machine](https://github.com/bad-antics/n01d-machine) - Secure VM manager with Tor/VPN integration and network isolation for analyzing malware and conducting anonymous investigations.
 
 # Cryptography
 


### PR DESCRIPTION
## Description
Adds two native Rust security tools to the Forensic section.

## About the Tools

### n01d-forge
- Native Rust image burner with LUKS/VeraCrypt encryption
- Perfect for creating secure forensic images
- Cross-platform GUI with egui

### n01d-machine
- Secure VM manager with Tor/VPN integration
- Network isolation for malware analysis
- Anonymous investigation environment

**GitHub Links**:
- https://github.com/bad-antics/n01d-forge
- https://github.com/bad-antics/n01d-machine

## Why Include?
- Both tools complement existing forensic tools
- Open source Rust implementations
- Focus on security and evidence preservation